### PR TITLE
Add GPG verification for Bash source and improve cleanup

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ all: build
 
 build: pull build-only
 build-only:
-	docker run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make -f makefile.bash'
+	docker run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash -c 'apt-get update && apt-get install -y gnupg && . ~/.bashrc && cd /root/workspace && make -f makefile.bash'
 
 shell:
 	docker run -it --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash
@@ -24,4 +24,4 @@ pull:
 	docker pull $(IMAGE_NAME)
 
 clean:
-	rm -rf build/*
+	docker run --rm -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make -f makefile.bash clean PLATFORM=$(PLATFORM)'

--- a/makefile.github
+++ b/makefile.github
@@ -7,7 +7,7 @@
 
 # Fetches the bash source code and commits the state to a Docker image (minui_bash:v1).
 fetch:
-	docker run --name build_container_1 -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash -c '. ~/.bashrc && cd /root/workspace && make -f makefile.bash build/bash-$(BASH_VERSION)/extract'
+	docker run --name build_container_1 -v $(HOST_WORKSPACE):$(GUEST_WORKSPACE) $(IMAGE_NAME) /bin/bash -c 'apt-get update && apt install -y gnupg && . ~/.bashrc && cd /root/workspace && make -f makefile.bash build/bash-$(BASH_VERSION)/extract'
 	docker commit build_container_1 minui_bash:v1
 	docker rm build_container_1
 


### PR DESCRIPTION
This commit introduces GPG signature verification for the Bash source tarball downloaded during the build process as well as improves cleanup by moving it to inside the container.