### PR TITLE
Refactor: Simplify makefile.bash by including main makefile

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,11 @@
+# Configuration variables for other makefiles.
+# Defines things like Bash version, workspace paths, platform, etc that are
+# shared across the different makefiles.
+
+BASH_VERSION = 5.2
+
+HOST_WORKSPACE = $(shell pwd)
+GUEST_WORKSPACE = /root/workspace
+
+PLATFORM ?= tg5040
+IMAGE_NAME = ghcr.io/loveretro/$(PLATFORM)-toolchain:modernize

--- a/makefile
+++ b/makefile
@@ -2,12 +2,7 @@
 # build operations. It orchestrates the use of 'makefile.bash' inside
 # a Docker container.
 
-BASH_VERSION = 5.2
-HOST_WORKSPACE = $(shell pwd)
-GUEST_WORKSPACE = /root/workspace
-
-PLATFORM ?= tg5040
-IMAGE_NAME = ghcr.io/loveretro/$(PLATFORM)-toolchain:modernize
+-include config.mk
 
 .PHONY: all build build-only shell pull clean
 

--- a/makefile.bash
+++ b/makefile.bash
@@ -1,7 +1,9 @@
 # This makefile contains the core logic for building the bash binary.
 # It is designed to be run inside a Docker container by the main 'makefile'.
 
-BASH_VERSION = 5.2
+# Get shared variables from the main makefile
+-include makefile
+
 BASH_SOURCE = bash-$(BASH_VERSION).tar.gz
 BASH_SOURCE_SIG = $(BASH_SOURCE).sig
 BUILD_DIR = build/bash-$(BASH_VERSION)

--- a/makefile.bash
+++ b/makefile.bash
@@ -1,8 +1,7 @@
 # This makefile contains the core logic for building the bash binary.
 # It is designed to be run inside a Docker container by the main 'makefile'.
 
-# Get shared variables from the main makefile
--include makefile
+-include config.mk
 
 BASH_SOURCE = bash-$(BASH_VERSION).tar.gz
 BASH_SOURCE_SIG = $(BASH_SOURCE).sig

--- a/makefile.github
+++ b/makefile.github
@@ -2,8 +2,7 @@
 # It breaks down the bash build process into granular, cachable Docker steps
 # to optimize CI/CD performance by layering Docker image commits.
 
-# Include the main makefile to access common variables like BASH_VERSION, HOST_WORKSPACE, etc.
--include makefile
+-include config.mk
 
 # Fetches the bash source code and commits the state to a Docker image (minui_bash:v1).
 fetch:


### PR DESCRIPTION
Removed redundant BASH_VERSION definition in makefile.bash and instead include the main makefile to inherit the shared BASH_VERSION.